### PR TITLE
Add Sprockets

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gem 'tzinfo-data', platforms: [:mswin, :mingw, :jruby]
 gem "middleman", "~> 4.1"
 gem "middleman-blog"
 gem "middleman-ember", path: "vendor/frontside/middleman-ember"
+gem 'middleman-sprockets'
 
 gem 'redcarpet', '~> 3.3', '>= 3.3.3'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,6 +80,9 @@ GEM
       servolux
       tilt (~> 1.4.1)
       uglifier (~> 3.0)
+    middleman-sprockets (4.0.0)
+      middleman-core (~> 4.0)
+      sprockets (>= 3.0)
     minitest (5.9.0)
     padrino-helpers (0.13.2)
       i18n (~> 0.6, >= 0.6.7)
@@ -95,6 +98,9 @@ GEM
     redcarpet (3.3.4)
     sass (3.4.22)
     servolux (0.12.0)
+    sprockets (3.6.3)
+      concurrent-ruby (~> 1.0)
+      rack (> 1, < 3)
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (1.4.1)
@@ -111,6 +117,7 @@ DEPENDENCIES
   middleman (~> 4.1)
   middleman-blog
   middleman-ember!
+  middleman-sprockets
   redcarpet (~> 3.3, >= 3.3.3)
   tzinfo-data
   wdm (~> 0.1.0)

--- a/config.rb
+++ b/config.rb
@@ -61,3 +61,5 @@ configure :build do
   # Minify Javascript on build
   # activate :minify_javascript
 end
+
+activate :sprockets


### PR DESCRIPTION
Sprockets are what currently break the build on new.frontside.io

I have added this `gem` which breaks the build, and I expect we have to extend [middleman_resource from middleman_sprockets extensions](https://github.com/middleman/middleman-sprockets/blob/master/lib/middleman-sprockets/extension.rb#L89)

``` ruby
def middleman_resource(path)
```

We have to set the paths in a very similar way as we did in https://github.com/flexyford/middleman-project-v4/blob/master/vendor/frontside/middleman-ember/lib/middleman-ember.rb#L291
